### PR TITLE
Better test for undefined in javascript

### DIFF
--- a/javascript/hamming/index.js
+++ b/javascript/hamming/index.js
@@ -10,7 +10,7 @@ class Hamming {
 
   compute(dna1, dna2) {
     // Added a test to ensure both inputs are provided
-    if (!dna1 || !dna2) {
+    if (typeof dna1 === 'undefined' || typeof dna2 === 'undefined') {
       throw 'Two DNA strands are required.';
     }
 

--- a/javascript/test/hamming.spec.js
+++ b/javascript/test/hamming.spec.js
@@ -16,6 +16,10 @@ describe('Hamming', function () {
     expect(hamming.compute('AG','CT')).to.equal(2);
   });
 
+  it('complete hamming distance for empty strands', function() {
+    expect(hamming.compute('', '')).to.equal(0);
+  });
+
   it('small hamming distance', function () {
     expect(hamming.compute('AT','CT')).to.equal(1);
   });
@@ -37,6 +41,6 @@ describe('Hamming', function () {
   });
 
   it('throws error when two strands are not provided', function() {
-    expect(function() { hamming.compute('AGGAC', ''); }).to.throw('Two DNA strands are required.');
+    expect(function() { hamming.compute('AGGAC'); }).to.throw('Two DNA strands are required.');
   });
 });


### PR DESCRIPTION
Noticed in the Python module that there is a test for empty strands (which should work); updated the Javascript module to test for empty strands as well as when one is undefined.