### PR TITLE
Adds Hamming.compute() method for python

### DIFF
--- a/python/hamming/__init__.py
+++ b/python/hamming/__init__.py
@@ -1,7 +1,40 @@
-# Define your compute function here.
-# run python -m unittest test.hamming_test to ensure the
-# unit tests pass and your code meets all of the conditions.
-#
+def compute(dna1 = None, dna2 = None):
+    """
+    Determines the Hamming distance between two DNA strands.
 
-def compute():
-    pass
+    Parameters
+    ----------
+    dna1 : str
+        A string representation of a DNA strand
+    dna2 : str
+        A string representation of a DNA strand
+
+    Returns
+    -------
+    int
+        This returns the Hamming distance of two DNA strands
+    """
+
+    """Added a test to ensure both inputs are provided."""
+    if dna1 is None or dna2 is None:
+        raise NameError('Two DNA strands are required.')
+
+    """Converted the strings into lists"""
+    dna1 = list(dna1)
+    dna2 = list(dna2)
+
+    """Enforces the requirement that DNA must be the same length"""
+    if len(dna1) != len(dna2):
+        raise ValueError('DNA strands must be of equal length.')
+
+    """Summer initialized outside the scope of the for... loop"""
+    distance = 0
+
+    """Uses enumerate() which replaces range(len()) and provides index"""
+    for ind, atom1 in enumerate(dna1):
+        atom2 = dna2[ind]
+
+        if (atom1 != atom2):
+            distance += 1
+
+    return distance

--- a/python/test/hamming_test.py
+++ b/python/test/hamming_test.py
@@ -55,6 +55,10 @@ class HammingTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             hamming.compute('ATA', 'AGTG')
 
+    def test_disallow_strand_missing(self):
+        with self.assertRaises(NameError):
+            hamming.compute('AGGAC')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Introduces `compute()` method for the hamming module which accepts two DNA strands (as strings) and returns the Hamming distance between them.

Adds an additional test which determines if two valid strings are provided.